### PR TITLE
AWS Firehose batch improve

### DIFF
--- a/examples/firehose.php
+++ b/examples/firehose.php
@@ -26,7 +26,11 @@ for ($c = 1; $c<=$limit; $c++) {
     switch ($method) {
         case "raw":
 
-            $data = array();
+            $data = array(
+                "pid" => getmypid(),
+                "count" => $c,
+            );
+
             for ($sadd = 0; $sadd < 5; $sadd++) { 
                 $data["list"] = randString(10);
             }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version = "6.0.2"
+	version = "6.0.3-dev"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version = "6.0.2-dev"
+	version = "6.0.2"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version = "6.0.3-dev"
+	version = "6.0.3"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	version = "6.0.1"
+	version = "6.0.2-dev"
 )
 
 var (

--- a/redis/fh/client.go
+++ b/redis/fh/client.go
@@ -116,9 +116,8 @@ func (clt *Client) flush() {
 
 	for _, r := range clt.records {
 		if r.len()+b.Len()+1 >= maxRecordSize {
-			bs := append([]byte(nil), b.Bytes()...)
+			records = append(records, &firehose.Record{Data: b.Bytes()})
 			b.Reset()
-			records = append(records, &firehose.Record{Data: bs})
 		}
 
 		b.Write(r.bytes())
@@ -126,8 +125,8 @@ func (clt *Client) flush() {
 	}
 
 	if b.Len() > 0 {
-		bs := append([]byte(nil), b.Bytes()...)
-		records = append(records, &firehose.Record{Data: bs})
+		records = append(records, &firehose.Record{Data: b.Bytes()})
+		b.Reset()
 	}
 
 	req, _ := clt.srv.awsSvc.PutRecordBatchRequest(&firehose.PutRecordBatchInput{

--- a/redis/fh/client.go
+++ b/redis/fh/client.go
@@ -116,8 +116,7 @@ func (clt *Client) flush() {
 	for _, r := range clt.records {
 		if r.len()+b.Len()+1 >= maxRecordSize {
 			bs := append([]byte(nil), b.Bytes()...)
-			buffPool.Put(b)
-			b = buffPool.Get()
+			b.Reset()
 			records = append(records, &firehose.Record{Data: bs})
 		}
 
@@ -127,7 +126,6 @@ func (clt *Client) flush() {
 
 	if b.Len() > 0 {
 		bs := append([]byte(nil), b.Bytes()...)
-
 		buffPool.Put(b)
 		records = append(records, &firehose.Record{Data: bs})
 	}

--- a/redis/fh/client.go
+++ b/redis/fh/client.go
@@ -112,7 +112,7 @@ func (clt *Client) flush() {
 	records := make([]*firehose.Record, 0)
 
 	b := buffPool.Get()
-	defer buffPool.Put(b)
+	b.Reset()
 
 	for _, r := range clt.records {
 		if r.len()+b.Len()+1 >= maxRecordSize {
@@ -126,8 +126,9 @@ func (clt *Client) flush() {
 
 	if b.Len() > 0 {
 		records = append(records, &firehose.Record{Data: b.Bytes()})
-		b.Reset()
 	}
+
+	defer buffPool.Put(b)
 
 	req, _ := clt.srv.awsSvc.PutRecordBatchRequest(&firehose.PutRecordBatchInput{
 		DeliveryStreamName: aws.String(clt.srv.config.StreamName),

--- a/redis/fh/client.go
+++ b/redis/fh/client.go
@@ -112,6 +112,7 @@ func (clt *Client) flush() {
 	records := make([]*firehose.Record, 0)
 
 	b := buffPool.Get()
+	defer buffPool.Put(b)
 
 	for _, r := range clt.records {
 		if r.len()+b.Len()+1 >= maxRecordSize {
@@ -126,7 +127,6 @@ func (clt *Client) flush() {
 
 	if b.Len() > 0 {
 		bs := append([]byte(nil), b.Bytes()...)
-		buffPool.Put(b)
 		records = append(records, &firehose.Record{Data: bs})
 	}
 

--- a/redis/fh/main.go
+++ b/redis/fh/main.go
@@ -23,7 +23,7 @@ type Server struct {
 	listener net.Listener
 
 	clients        []*Client
-	recordsCh      chan *record
+	recordsCh      chan *interRecord
 	awsSvc         *firehose.Firehose
 	lastConnection time.Time
 	lastError      time.Time
@@ -68,7 +68,7 @@ func New(c lib.RelayerConfig, done chan bool) (*Server, error) {
 	srv := &Server{
 		done:      done,
 		errors:    0,
-		recordsCh: make(chan *record, requestBufferSize),
+		recordsCh: make(chan *interRecord, requestBufferSize),
 	}
 
 	srv.Reload(&c)
@@ -153,9 +153,8 @@ func (srv *Server) canSend() bool {
 	return true
 }
 
-func (srv *Server) sendRecord(r *record) {
+func (srv *Server) sendRecord(r *interRecord) {
 	if !srv.canSend() {
-		putPool(r)
 		return
 	}
 
@@ -163,15 +162,14 @@ func (srv *Server) sendRecord(r *record) {
 	case srv.recordsCh <- r:
 	default:
 		lib.Debugf("Firehose: channel is full. Queued messages %d", len(srv.recordsCh))
-		putPool(r)
 	}
 }
 
 func (srv *Server) sendBytes(b []byte) {
-	r := fromPool()
-	r.types = 1
-	r.raw = b
-
+	r := &interRecord{
+		types: 1,
+		raw:   b,
+	}
 	srv.sendRecord(r)
 }
 
@@ -184,11 +182,10 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 	// Active transaction
 	multi := false
 
-	var record *record
+	var row *interRecord
 	defer func() {
 		if multi {
 			log.Println("Firehose ERROR: MULTI closed before ending with EXEC")
-			putPool(record)
 		}
 	}()
 
@@ -228,29 +225,35 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 			srv.sendBytes(src)
 		case "MULTI":
 			multi = true
-			record = fromPool()
+			row = &interRecord{
+				types: 1,
+			}
 		case "EXEC":
 			multi = false
-			srv.sendRecord(record)
+			srv.sendRecord(row)
 		case "SET":
 			k, _ := req.Items[1].Str()
 			v, _ := req.Items[2].Str()
 			if multi {
-				record.add(k, v)
+				row.add(k, v)
 			} else {
-				record = fromPool()
-				record.add(k, v)
-				srv.sendRecord(record)
+				row = &interRecord{
+					types: 1,
+				}
+				row.add(k, v)
+				srv.sendRecord(row)
 			}
 		case "SADD":
 			k, _ := req.Items[1].Str()
 			v, _ := req.Items[2].Str()
 			if multi {
-				record.sadd(k, v)
+				row.sadd(k, v)
 			} else {
-				record = fromPool()
-				record.sadd(k, v)
-				srv.sendRecord(record)
+				row = &interRecord{
+					types: 1,
+				}
+				row.sadd(k, v)
+				srv.sendRecord(row)
 			}
 		case "HMSET":
 			var key string
@@ -258,7 +261,9 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 			var v string
 
 			if !multi {
-				record = fromPool()
+				row = &interRecord{
+					types: 1,
+				}
 			}
 
 			for i, o := range req.Items[1:] {
@@ -272,12 +277,12 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 					k, _ = o.Str()
 				} else {
 					v, _ = o.Str()
-					record.mhset(key, k, v)
+					row.mhset(key, k, v)
 				}
 			}
 
 			if !multi {
-				srv.sendRecord(record)
+				srv.sendRecord(row)
 			}
 
 		}

--- a/redis/fh/main.go
+++ b/redis/fh/main.go
@@ -32,7 +32,7 @@ type Server struct {
 
 const (
 	maxConnections      = 2
-	requestBufferSize   = 1024 * 5
+	requestBufferSize   = 1024 * 10
 	maxConnectionsTries = 3
 	connectionRetry     = 5 * time.Second
 	errorsFrame         = 10 * time.Second

--- a/redis/fh/main.go
+++ b/redis/fh/main.go
@@ -225,9 +225,7 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 			srv.sendBytes(src)
 		case "MULTI":
 			multi = true
-			row = &interRecord{
-				types: 1,
-			}
+			row = &interRecord{}
 		case "EXEC":
 			multi = false
 			srv.sendRecord(row)
@@ -237,9 +235,7 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 			if multi {
 				row.add(k, v)
 			} else {
-				row = &interRecord{
-					types: 1,
-				}
+				row = &interRecord{}
 				row.add(k, v)
 				srv.sendRecord(row)
 			}
@@ -249,9 +245,7 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 			if multi {
 				row.sadd(k, v)
 			} else {
-				row = &interRecord{
-					types: 1,
-				}
+				row = &interRecord{}
 				row.sadd(k, v)
 				srv.sendRecord(row)
 			}
@@ -262,7 +256,7 @@ func (srv *Server) handleConnection(netCon net.Conn) {
 
 			if !multi {
 				row = &interRecord{
-					types: 1,
+					types: 0,
 				}
 			}
 

--- a/redis/fh/record.go
+++ b/redis/fh/record.go
@@ -2,53 +2,24 @@ package fh
 
 import (
 	"log"
-	"sync"
-	"time"
 
 	"github.com/pquerna/ffjson/ffjson"
 )
 
-type record struct {
+type interRecord struct {
 	types     int
 	Timestamp float64                `json:"_ts"`
 	Data      map[string]interface{} `json:"data"`
 	raw       []byte                 // 0 json, 1 raw bytes
 }
 
-var reqPool = sync.Pool{
-	New: func() interface{} {
-		return &record{
-			Data: make(map[string]interface{}),
-		}
-	},
-}
-
-func fromPool() *record {
-	r := reqPool.Get().(*record)
-	r.Timestamp = float64(time.Now().UnixNano()) / float64(time.Nanosecond)
-	return r
-}
-
-func putPool(r *record) {
-	r.types = 0
-	r.raw = nil
-	if len(r.Data) < 100 {
-		for i := range r.Data {
-			delete(r.Data, i)
-		}
-	} else {
-		r.Data = make(map[string]interface{})
-	}
-	reqPool.Put(r)
-}
-
-func (r *record) add(key, value string) {
+func (r *interRecord) add(key, value string) {
 	if _, ok := r.Data[key]; !ok {
 		r.Data[key] = value
 	}
 }
 
-func (r *record) sadd(key, value string) {
+func (r *interRecord) sadd(key, value string) {
 	if _, ok := r.Data[key]; !ok {
 		r.Data[key] = make([]interface{}, 0)
 	}
@@ -56,7 +27,7 @@ func (r *record) sadd(key, value string) {
 	r.Data[key] = append(r.Data[key].([]interface{}), value)
 }
 
-func (r *record) mhset(key, k string, v interface{}) {
+func (r *interRecord) mhset(key, k string, v interface{}) {
 	if _, ok := r.Data[key]; !ok {
 		r.Data[key] = make(map[string]interface{})
 	}
@@ -64,7 +35,7 @@ func (r *record) mhset(key, k string, v interface{}) {
 	r.Data[key].(map[string]interface{})[k] = v
 }
 
-func (r *record) bytes() []byte {
+func (r *interRecord) bytes() []byte {
 	if r.types != 0 {
 		return r.raw
 	}
@@ -77,7 +48,7 @@ func (r *record) bytes() []byte {
 	return buf
 }
 
-func (r *record) len() int {
+func (r *interRecord) len() int {
 	if r.types != 0 {
 		return len(r.raw)
 	}


### PR DESCRIPTION
AWS Firehose charge by record, with these changes smart-relayer will group all the messages as he can in one record. The limits are defined in the code following the documentation of AWS and there is a variable that can be defined in the config file to limit the number of rows that can be added in one record. Finally the records will be send in batch as the prev version.