### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/lib/listener.go
+++ b/lib/listener.go
@@ -11,7 +11,7 @@ type Listener struct {
 	listener net.Listener
 }
 
-// MewListener check sockets and files and return a listener alread listening
+// NewListener check sockets and files and return a listener alread listening
 func NewListener(c RelayerConfig) (l *Listener, e error) {
 	l = &Listener{
 		config: c,

--- a/redis/radix.improved/redis/resp.go
+++ b/redis/radix.improved/redis/resp.go
@@ -162,7 +162,7 @@ func NewRespReader(r io.Reader) *RespReader {
 	return &RespReader{br}
 }
 
-// ReadResp attempts to read a message object from the given io.Reader, parse
+// Read attempts to read a message object from the given io.Reader, parse
 // it, and return a Resp representing it
 func (rr *RespReader) Read() *Resp {
 	res, err := bufioReadResp(rr.r)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?