### PR TITLE
To make it compatible with StackExchange.Redis .NET

### DIFF
--- a/lib/conf.go
+++ b/lib/conf.go
@@ -55,7 +55,8 @@ type RelayerConfig struct {
 	Writers         int // Writers BY shard (each shard will have the number of workers defined here)
 	BreakMultiplier int // Limit to declare as failing. Total writes plus this value
 
-	AsynCommands string
+	AsynCommands   string
+	IgnoreCommands string // All commands included here are going to be answer as "1"
 }
 
 func ReadConfig(filename string) (config *Config, err error) {

--- a/relayer.conf
+++ b/relayer.conf
@@ -38,6 +38,7 @@ maxConnections = 2
 maxRecords = 100
 streamName = "testing"
 region = "eu-west-1"
+ignoreCommands = "SET GET"
 #profile = "yourprofilename" # Profile for authentication
 
 # Kinesis Firehose over http


### PR DESCRIPTION
The StackExchange.Redis .NET lib is doing a PING, EXISTS and GET
command just after established the tcp connection. We include the
support of these commands and also the option to ignore commands defined
in the configuration (**ignoreCommands**):

```
[[relayer]]
protocol = "firehose"
mode = "smart"
listen = "unix:/tmp/firehose.sock"
maxConnections = 2
maxRecords = 100
streamName = "testing"
region = "eu-west-1"
ignoreCommands = "SET GET"
```

The commands included in the list of **ignoreCommands** will respond as **"1"
(true)** and stop the process. It will not send anything to the firehose.

We are doing this because of StackExchange.Redis does a SET before each op
to Redis.